### PR TITLE
Add Microsoft Clarity analytics

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+NUXT_CLARITY_ID=rofk24ejyf

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ content
 - [Nuxt Google Fonts](https://google-fonts.nuxtjs.org/)
 - [Nuxt Tailwind](https://tailwindcss.nuxtjs.org/)
 - [Nuxt Google Tag](https://nuxt.com/modules/gtag/)
+- [Nuxt Clarity Analytics](https://npm.im/nuxt-clarity-analytics)
 - [Nuxt AOS](https://nuxt.com/modules/aos)
 - [Vue Router](https://router.vuejs.org/)
 - [TinyPNG](https://tinypng.com/)

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -17,6 +17,7 @@ export default defineNuxtConfig({
     "@nuxtjs/tailwindcss",
     "@nuxtjs/google-fonts",
     "@nuxt/content",
+    "nuxt-clarity-analytics",
     "nuxt-gtag",
     "nuxt-aos",
   ],
@@ -39,5 +40,9 @@ export default defineNuxtConfig({
 
   aos: {
     duration: 750,
+  },
+
+  runtimeConfig: {
+    clarityId: process.env.NUXT_CLARITY_ID || "",
   },
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@nuxtjs/tailwindcss": "^6.13.2",
         "nuxt": "^3.16.2",
         "nuxt-aos": "^1.2.5",
+        "nuxt-clarity-analytics": "^0.0.9",
         "nuxt-gtag": "^3.0.2",
         "vue": "^3.5.13",
         "vue-router": "^4.5.0"
@@ -10864,6 +10865,15 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "license": "ISC"
+    },
+    "node_modules/nuxt-clarity-analytics": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/nuxt-clarity-analytics/-/nuxt-clarity-analytics-0.0.9.tgz",
+      "integrity": "sha512-H5w+B5XOm9hdoVn3CnDCKIcnZli48UwuD8fP1bOogse0NVxNDUKhW0pdqOMRkniL/oORiqIwMrEZh12YE+23KQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@nuxt/kit": "^3.13.1"
+      }
     },
     "node_modules/nuxt-component-meta": {
       "version": "0.11.0",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@nuxtjs/tailwindcss": "^6.13.2",
     "nuxt": "^3.16.2",
     "nuxt-aos": "^1.2.5",
+    "nuxt-clarity-analytics": "^0.0.9",
     "nuxt-gtag": "^3.0.2",
     "vue": "^3.5.13",
     "vue-router": "^4.5.0"

--- a/vercel.json
+++ b/vercel.json
@@ -23,7 +23,7 @@
       "headers": [
         {
           "key": "Content-Security-Policy",
-         "value": "default-src 'self' https: data:; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.googletagmanager.com https://www.google-analytics.com https://s3.amazonaws.com https://vercel.live; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data:; connect-src 'self' https://www.google-analytics.com; img-src 'self' data: https:; object-src 'none'; frame-src https://*.mailchimp.com https://vercel.live;"
+        "value": "default-src 'self' https: data:; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.googletagmanager.com https://www.google-analytics.com https://www.clarity.ms https://s3.amazonaws.com https://vercel.live; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data:; connect-src 'self' https://www.google-analytics.com https://www.clarity.ms; img-src 'self' data: https:; object-src 'none'; frame-src https://*.mailchimp.com https://vercel.live;"
         },
         {
           "key": "X-Frame-Options",


### PR DESCRIPTION
## Summary
- integrate Microsoft Clarity with `nuxt-clarity-analytics`
- allow Clarity domain in CSP headers
- expose `NUXT_CLARITY_ID` via runtime config
- document Clarity module in README
- provide `.env.example`

## Testing
- `npm run test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68481171b9a483309306f8edac80aa68