### PR TITLE
Update CSP for Clarity

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -23,7 +23,7 @@
       "headers": [
         {
           "key": "Content-Security-Policy",
-        "value": "default-src 'self' https: data:; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.googletagmanager.com https://www.google-analytics.com https://www.clarity.ms https://s3.amazonaws.com https://vercel.live; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data:; connect-src 'self' https://www.google-analytics.com https://www.clarity.ms wss://www.clarity.ms; img-src 'self' data: https:; object-src 'none'; frame-src https://*.mailchimp.com https://vercel.live https://www.clarity.ms;"
+        "value": "default-src 'self' https: data:; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.googletagmanager.com https://www.google-analytics.com https://www.clarity.ms https://s3.amazonaws.com https://vercel.live; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data:; connect-src 'self' https://www.google-analytics.com https://www.clarity.ms https://a.clarity.ms wss://www.clarity.ms; img-src 'self' data: https:; object-src 'none'; frame-src https://*.mailchimp.com https://vercel.live https://www.clarity.ms;"
         },
         {
           "key": "X-Frame-Options",


### PR DESCRIPTION
## Summary
- allow `https://a.clarity.ms` in the Content Security Policy so Clarity analytics can send data

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68485b4415e08330a5a408f9e136a025